### PR TITLE
Create Split-VideoForZoom.ps1

### DIFF
--- a/live_backgrounds/README.md
+++ b/live_backgrounds/README.md
@@ -47,7 +47,7 @@ Once those are installed, you can split up a video that you've downloaded with `
 ```
 cd awesome-zoom-backgrounds/live_backgrounds
 youtube-dl -f 134 'https://www.youtube.com/watch?v=3rDjPLvOShM' -o 'train.mp4'
-./Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4
+pwsh Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4
 ```
 
 This will, by default, split the video into enough 15 second chunks to make a 10 minute video.

--- a/live_backgrounds/README.md
+++ b/live_backgrounds/README.md
@@ -47,13 +47,15 @@ Once those are installed, you can split up a video that you've downloaded with `
 ```
 cd awesome-zoom-backgrounds/live_backgrounds
 youtube-dl -f 134 'https://www.youtube.com/watch?v=3rDjPLvOShM' -o 'train.mp4'
-pwsh Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4
+pwsh Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4 #Mac, Linux, Windows with PowerShell Core installed
+powershell Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4 #Windows
+
 ```
 
 This will, by default, split the video into enough 15 second chunks to make a 10 minute video.
 The length of clips and the total length of video can also be specified.
 
 ```
-./Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4 -VideoLength 5 -ClipTime 30
+pwsh Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4 -VideoLength 5 -ClipTime 30
 ```
 This will split the same video into enough 30 second clips to make a 5 minute video (so 10 clips total)

--- a/live_backgrounds/README.md
+++ b/live_backgrounds/README.md
@@ -3,23 +3,57 @@
 ## Why limit yourself non-moving Zoom backgrounds?
 _requires Zoom 4.6.4_
 
-Did you know you can add video backgrounds with Zoom? This quick tutorial will show you how to visit the 1980s on every video call. 
+Did you know you can add video backgrounds with Zoom? This quick tutorial will show you how to visit the 1980s on every video call.
 
 ![big-boat](big-boat.png)
 
-First, we need some tools. 
+First, we need some tools.
 
-`brew install youtube-dl` or the equivalent for your OS. 
+`brew install youtube-dl` or the equivalent for your OS.
 
 If you want to use the video from the screenshot above:
 
-`youtube-dl -F 'https://www.youtube.com/watch?v=GsN_9a257rM'` 
+`youtube-dl -F 'https://www.youtube.com/watch?v=GsN_9a257rM'`
 
 and then choose the appropriate stream, ie `youtube-dl -f 18 'https://www.youtube.com/watch?v=GsN_9a257rM'`
 
-_Zoom requires a minimum resolution of 640x360 for virtual backgrounds_ 
+_Zoom requires a minimum resolution of 640x360 for virtual backgrounds_
 
-Next, go to Zoom preferences and add the video you just downloaded. 
+Next, go to Zoom preferences and add the video you just downloaded.
 ![zoom-pref](zoom-pref.png)
 
 Proceed to enjoy the 1980s
+
+## More fun with moving backgrounds and Slow TV
+
+[Slow TV](https://en.wikipedia.org/wiki/Slow_television) can make for some fun live backgrounds, but your coworkers will get bored seeing
+the same 30 minutes from the beginning of a long video over and over (and the beginning may not have any action).
+[I wanted to split a large video](https://twitter.com/fishmanpet/status/1242585079446192129),
+and after deciding that doing it by hand would be very time consuming I looked into using ffmpeg and PowerShell,
+my scripting language of choice.
+
+I wrote this script that randomly select clips from a larger video and assemble them into a video suitable for use as a Zoom background.
+
+To use `Split-VideoForZoom.ps1` you'll need ffmpeg and PowerShell (will run on Windows PowerShell or PowerShell Core on any platform).
+
+On a Mac:
+
+`brew cask install powershell`
+
+`brew install ffmpeg`
+
+Once those are installed, you can split up a video that you've downloaded with `youtube-dl` as above.
+
+```
+cd awesome-zoom-backgrounds/live_backgrounds
+youtube-dl -f 134 'https://www.youtube.com/watch?v=3rDjPLvOShM' -o 'train.mp4'
+./Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4
+```
+
+This will, by default, split the video into enough 15 second chunks to make a 10 minute video.
+The length of clips and the total length of video can also be specified.
+
+```
+./Split-VideoForZoom.ps1 -VideoPath train.mp4 -OutputPath split.mp4 -VideoLength 5 -ClipTime 30
+```
+This will split the same video into enough 30 second clips to make a 5 minute video (so 10 clips total)

--- a/live_backgrounds/Split-VideoForZoom.ps1
+++ b/live_backgrounds/Split-VideoForZoom.ps1
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env pwsh
+#!/usr/bin/env pwsh
 
 <#
     .SYNOPSIS

--- a/live_backgrounds/Split-VideoForZoom.ps1
+++ b/live_backgrounds/Split-VideoForZoom.ps1
@@ -1,0 +1,92 @@
+﻿
+<#
+    .SYNOPSIS
+    Splits a longer mp4 video into a few random short clips, for Zoom video backgrounds
+
+    .DESCRIPTION
+    Suitable for use with "Slow Television" videos, it will take a long video (in MP4 format), and cut random short clips together to make a single video.
+    It can also reverse or horizontally mirror the video.  By default the video will be 10 minutes long with 15 second clips, but this can be modified.
+
+    .PARAMETER videoPath
+    Path to the source video
+
+    .PARAMETER outputPath
+    Path and filename to output file
+
+    .PARAMETER reverse
+    If specified will reverse playback of the video
+
+    .PARAMETER mirror
+    If specified will mirror the video horizontally
+
+    .PARAMETER length
+    How many minutes long the output video should be. This is used along with time to determine how many clips to cut
+
+    .PARAMETER time
+    How long each clip should be. This is used along with length to determine how many clips to cut
+
+    .PARAMETER ffmpegPath
+    Optional, path to ffmpeg, defaults to simply ffmpeg, so only needed if ffmpeg is not in your path
+
+    .PARAMETER ffprobePath
+    Optional, path to ffprobe, defaults to simply ffprobe, so only needed if ffprobe is not in your path
+
+    .EXAMPLE
+    .\Split-VideoForZoom.ps1 -videoPath train.mp4 -outputPath zoom.mp4 -reverse -mirror -length 2 -time 15
+    This will split the file train.mp4 (https://www.youtube.com/watch?v=3rDjPLvOShM downloaded using youtubedl and renamed) into a 2 minute
+    long video made up of 15 second clips (8 clips total), reverse (when it wasn't reversed my coworkers thought it looked weird playing forwards,
+    so I reversed it), and mirrors it horizontally (Zoom can mirror your image but this will mirror any text in the video, so mirroring the video
+    means when zoom mirrors it, it will appear as normal)
+
+    #>
+param (
+    [Parameter(Mandatory = $true)][String]$videoPath,
+    [Parameter(Mandatory = $true)][String]$outputPath,
+    [Switch]$reverse,
+    [Switch]$mirror,
+    [Int]$length = 10,
+    [Int]$time = 15,
+    [String]$ffmpegPath = 'ffmpeg',
+    [String]$ffprobePath = 'ffprobe'
+)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    $videoPath = Resolve-Path $videoPath
+    if (Split-Path -Parent $outputPath) {
+        $outputpath = join-path (Resolve-Path (Split-Path -Parent $outputPath)) (Split-Path -Leaf $outputPath)
+    }
+
+    $videoInfo = (&$ffprobePath -v quiet -print_format json -show_format $videoPath ) | ConvertFrom-Json
+    [int]$seconds = $videoInfo.format[0].duration
+    [int]$intervals = ($length * 60) / $time
+
+    $dirname = Get-Date -Format FileDateTimeUniversal
+    New-Item -Name $dirname -ItemType Directory
+
+    foreach ($i in (1..$intervals)) {
+        $randomtotal = Get-Random -Maximum ($seconds - $time) -Minimum 0
+        $filename = Join-Path $dirname "clip$i.mp4"
+        Write-Verbose "Starting Clip $i at $randomtotal"
+        &$ffmpegPath -hide_banner -ss $randomtotal -i $videoPath -t $time $filename
+        "file '$(Resolve-Path $filename)'" | Out-File -Append (Join-Path $dirname mylist.txt) -Encoding ascii
+        Write-Verbose "Finished Clip $i at $randomtotal"
+    }
+    if ($reverse -or $mirror) {
+        $vfflags = @()
+        if ($reverse) {
+            $vfflags += 'reverse'
+        }
+        if ($mirror) {
+            $vfflags += 'hflip'
+        }
+        $vfflags =  "-vf", ($vfflags -join ',')
+    } else {
+        $vfflags = "-c", "copy"
+    }
+    $param = "-hide_banner", "-f", "concat", "-safe", "0", "-i", "$(Join-Path $dirname mylist.txt)" + $vfflags + "$outputpath"
+    &$ffmpegPath $param
+} finally {
+    Remove-Item -Recurse $dirname
+}

--- a/live_backgrounds/Split-VideoForZoom.ps1
+++ b/live_backgrounds/Split-VideoForZoom.ps1
@@ -1,5 +1,6 @@
 #!/usr/bin/env pwsh
 
+
 <#
     .SYNOPSIS
     Splits a longer mp4 video into a few random short clips, for Zoom video backgrounds

--- a/live_backgrounds/Split-VideoForZoom.ps1
+++ b/live_backgrounds/Split-VideoForZoom.ps1
@@ -1,29 +1,32 @@
-﻿
+﻿#!/usr/bin/env pwsh
+
 <#
     .SYNOPSIS
     Splits a longer mp4 video into a few random short clips, for Zoom video backgrounds
 
     .DESCRIPTION
     Suitable for use with "Slow Television" videos, it will take a long video (in MP4 format), and cut random short clips together to make a single video.
-    It can also reverse or horizontally mirror the video.  By default the video will be 10 minutes long with 15 second clips, but this can be modified.
+    It can also reverse or horizontally mirror the video. By default the video will be 10 minutes long with 15 second clips, but this can be modified.
 
-    .PARAMETER videoPath
+    .PARAMETER VideoPath
     Path to the source video
 
-    .PARAMETER outputPath
+    .PARAMETER OutputPath
     Path and filename to output file
 
-    .PARAMETER reverse
+    .PARAMETER VideoLength
+    How many minutes long the output video should be. This is used along with ClipTime to determine how many clips to cut
+
+    .PARAMETER ClipTime
+    How long each clip should be, in seconds. This is used along with VideoLength to determine how many clips to cut
+
+    .PARAMETER Reverse
     If specified will reverse playback of the video
 
-    .PARAMETER mirror
-    If specified will mirror the video horizontally
-
-    .PARAMETER length
-    How many minutes long the output video should be. This is used along with time to determine how many clips to cut
-
-    .PARAMETER time
-    How long each clip should be. This is used along with length to determine how many clips to cut
+    .PARAMETER Mirror
+    If specified will mirror the video horizontally.
+    By default Zoom will mirror how it shows your feed to you, but viewers will see an unmirroed version.
+    Normally you shouldn't need this for normal Zoom settings.
 
     .PARAMETER ffmpegPath
     Optional, path to ffmpeg, defaults to simply ffmpeg, so only needed if ffmpeg is not in your path
@@ -32,20 +35,19 @@
     Optional, path to ffprobe, defaults to simply ffprobe, so only needed if ffprobe is not in your path
 
     .EXAMPLE
-    .\Split-VideoForZoom.ps1 -videoPath train.mp4 -outputPath zoom.mp4 -reverse -mirror -length 2 -time 15
+    .\Split-VideoForZoom.ps1 -videoPath train.mp4 -outputPath zoom.mp4 -reverse -VideoLength 2 -ClipTime 15
     This will split the file train.mp4 (https://www.youtube.com/watch?v=3rDjPLvOShM downloaded using youtubedl and renamed) into a 2 minute
-    long video made up of 15 second clips (8 clips total), reverse (when it wasn't reversed my coworkers thought it looked weird playing forwards,
-    so I reversed it), and mirrors it horizontally (Zoom can mirror your image but this will mirror any text in the video, so mirroring the video
-    means when zoom mirrors it, it will appear as normal)
+    long video made up of 15 second clips (8 clips total), in reverse (when it wasn't reversed my coworkers thought it looked weird playing forwards,
+    so I reversed it).
 
     #>
 param (
-    [Parameter(Mandatory = $true)][String]$videoPath,
-    [Parameter(Mandatory = $true)][String]$outputPath,
-    [Switch]$reverse,
-    [Switch]$mirror,
-    [Int]$length = 10,
-    [Int]$time = 15,
+    [Parameter(Mandatory = $true)][String]$VideoPath,
+    [Parameter(Mandatory = $true)][String]$OutputPath,
+    [Alias("length")][Int]$VideoLength = 10,
+    [Alias("time")][Int]$ClipTime = 15,
+    [Switch]$Reverse,
+    [Switch]$Mirror,
     [String]$ffmpegPath = 'ffmpeg',
     [String]$ffprobePath = 'ffprobe'
 )
@@ -60,16 +62,16 @@ try {
 
     $videoInfo = (&$ffprobePath -v quiet -print_format json -show_format $videoPath ) | ConvertFrom-Json
     [int]$seconds = $videoInfo.format[0].duration
-    [int]$intervals = ($length * 60) / $time
+    [int]$intervals = ($VideoLength * 60) / $ClipTime
 
     $dirname = Get-Date -Format FileDateTimeUniversal
     New-Item -Name $dirname -ItemType Directory
 
     foreach ($i in (1..$intervals)) {
-        $randomtotal = Get-Random -Maximum ($seconds - $time) -Minimum 0
+        $randomtotal = Get-Random -Maximum ($seconds - $ClipTime) -Minimum 0
         $filename = Join-Path $dirname "clip$i.mp4"
         Write-Verbose "Starting Clip $i at $randomtotal"
-        &$ffmpegPath -hide_banner -ss $randomtotal -i $videoPath -t $time $filename
+        &$ffmpegPath -hide_banner -ss $randomtotal -i $videoPath -t $ClipTime $filename
         "file '$(Resolve-Path $filename)'" | Out-File -Append (Join-Path $dirname mylist.txt) -Encoding ascii
         Write-Verbose "Finished Clip $i at $randomtotal"
     }

--- a/live_backgrounds/Split-VideoForZoom.ps1.md
+++ b/live_backgrounds/Split-VideoForZoom.ps1.md
@@ -1,0 +1,172 @@
+---
+external help file: -help.xml
+Module Name:
+online version:
+schema: 2.0.0
+---
+
+# Split-VideoForZoom.ps1
+
+## SYNOPSIS
+Splits a longer mp4 video into a few random short clips, for Zoom video backgrounds
+
+## SYNTAX
+
+```
+Split-VideoForZoom.ps1 [-VideoPath] <String> [-OutputPath] <String> [[-VideoLength] <Int32>]
+ [[-ClipTime] <Int32>] [-Reverse] [-Mirror] [[-ffmpegPath] <String>] [[-ffprobePath] <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Suitable for use with "Slow Television" videos, it will take a long video (in MP4 format), and cut random short clips together to make a single video.
+It can also reverse or horizontally mirror the video.
+By default the video will be 10 minutes long with 15 second clips, but this can be modified.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+.\Split-VideoForZoom.ps1 -videoPath train.mp4 -outputPath zoom.mp4 -reverse -VideoLength 2 -ClipTime 15
+```
+
+This will split the file train.mp4 (https://www.youtube.com/watch?v=3rDjPLvOShM downloaded using youtubedl and renamed) into a 2 minute
+long video made up of 15 second clips (8 clips total), in reverse (when it wasn't reversed my coworkers thought it looked weird playing forwards,
+so I reversed it).
+
+## PARAMETERS
+
+### -VideoPath
+Path to the source video
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputPath
+Path and filename to output file
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VideoLength
+How many minutes long the output video should be.
+This is used along with ClipTime to determine how many clips to cut
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: length
+
+Required: False
+Position: 3
+Default value: 10
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClipTime
+How long each clip should be, in seconds.
+This is used along with VideoLength to determine how many clips to cut
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: time
+
+Required: False
+Position: 4
+Default value: 15
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Reverse
+If specified will reverse playback of the video
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Mirror
+If specified will mirror the video horizontally.
+By default Zoom will mirror how it shows your feed to you, but viewers will see an unmirroed version.
+Normally you shouldn't need this for normal Zoom settings.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ffmpegPath
+Optional, path to ffmpeg, defaults to simply ffmpeg, so only needed if ffmpeg is not in your path
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: Ffmpeg
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ffprobePath
+Optional, path to ffprobe, defaults to simply ffprobe, so only needed if ffprobe is not in your path
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: Ffprobe
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
Powershell script that will randomly cut up a long video into a series of short clips.  I wanted to use some "slow television" videos as zoom backgrounds but I didn't want meeting attendees to always be subjected to the first 30-60 minutes of hours long videos, so I wanted to keep it fresh by cutting some clips together.  I turned to ffmpeg and Powershell.  I wrote this on my Windows machine but with Powershell 7, which is cross platform.  However I haven't tested it on anything but Windows because I don't have access to anything else, so caveat emptor!